### PR TITLE
Fix link to presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# [View presentation](trueter.github.io/react-berlin-recompose)
+# [View presentation](http://trueter.github.io/react-berlin-recompose)
 


### PR DESCRIPTION
Otherwise it links to https://github.com/trueter/react-berlin-recompose/blob/master/trueter.github.io/react-berlin-recompose
